### PR TITLE
Add yarn local-invocation for quicker testing

### DIFF
--- a/dummy-event.json
+++ b/dummy-event.json
@@ -1,0 +1,4 @@
+{
+  "path": "/xxxx-xxxx-xxxx",
+  "isOffline": true
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:fix": "prettier \"**/*.*\" --write --loglevel warn && eslint . --fix",
     "pretest": "npm run lint",
     "test": "jest --coverage",
+    "local-invocation": "serverless invoke local --function hours --path ./dummy-event.json",
     "start": "serverless offline start",
     "deploy": "npm run deploy:dev && npm run deploy:prod",
     "deploy:dev": "serverless deploy -v",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "deploy": "npm run deploy:dev && npm run deploy:prod",
     "deploy:dev": "serverless deploy -v",
     "deploy:prod": "serverless deploy -v --stage prod",
-    "remove-deploys": "serverless remove -v && serverless remove -v --stage prod"
+    "remove-deploys": "serverless remove -v && serverless remove -v --stage prod",
+    "check-all-pull-request-commits": "git rebase origin/master --exec \"yarn test && yarn local-invocation\""
   },
   "author": "Daniel Edholm Ignat",
   "license": "MIT",


### PR DESCRIPTION
This is needed due to differences in module resolution between test code and real code, which not even integration tests catch