### PR TITLE
Replace serverless-dotenv-plugin, plugin not supported in v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5597,12 +5597,6 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
-    "dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-      "dev": true
-    },
     "download": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-8.0.0.tgz",
@@ -17563,68 +17557,6 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
           "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
           "dev": true
-        }
-      }
-    },
-    "serverless-dotenv-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.1.0.tgz",
-      "integrity": "sha512-R9Jld4a/hDDd0lHiSq9xQuFlhtfgXqKKmODrYp7115iQ9kgf16SMxZbxJ0Cb9GqL6/4+5GlS42iHxsqv8GxZeQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "dotenv": "^8.2.0",
-        "dotenv-expand": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "mockdate": "^3.0.2",
     "prettier": "2.1.2",
     "serverless": "^2.9.0",
-    "serverless-dotenv-plugin": "^3.1.0",
     "serverless-offline": "^6.8.0"
   },
   "dependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,11 +16,11 @@ functions:
     handler: src/index.hours
     events:
       - http:
-          path: /${env:SECRET_URL_SLUG}
+          path: /${self:custom.dotenvVars.SECRET_URL_SLUG}
           method: get
     environment:
-      HARVEST_ACCESS_TOKEN: ${env:HARVEST_ACCESS_TOKEN}
-      HARVEST_ACCOUNT_ID: ${env:HARVEST_ACCOUNT_ID}
+      HARVEST_ACCESS_TOKEN: ${self:custom.dotenvVars.HARVEST_ACCESS_TOKEN}
+      HARVEST_ACCOUNT_ID: ${self:custom.dotenvVars.HARVEST_ACCOUNT_ID}
   rootPath:
     handler: src/index.root
     events:
@@ -33,6 +33,7 @@ package:
     - .github/**
     - .vscode/**
     - examples/**
+    - .env
     - .env.example
     - .eslintignore
     - .eslintrc.json
@@ -46,4 +47,8 @@ package:
 
 plugins:
   - serverless-offline
-  - serverless-dotenv-plugin
+
+custom:
+  # Do this if you only want to load env vars into the Serverless environment
+  # This will make env vars available here and in any Serverless plugins
+  dotenvVars: ${file(src/load-dotenv-into-serverless-yml.js)}

--- a/src/load-dotenv-into-serverless-yml.js
+++ b/src/load-dotenv-into-serverless-yml.js
@@ -1,0 +1,11 @@
+const dotenv = require("dotenv");
+
+module.exports = async () => {
+  // Load env vars into Serverless environment
+  const envVars = dotenv.config({ path: ".env" }).parsed;
+  return Object.assign(
+    {},
+    envVars, // `dotenv` environment variables
+    process.env // system environment variables
+  );
+};


### PR DESCRIPTION
Using technique described in https://github.com/neverendingqs/serverless-dotenv-example/ which does not need a third party plugin to work.

[Built in dotenv support](https://www.serverless.com/framework/docs/environment-variables/) does not expose variables to `serverless.yml` and is only for local development.

I think [the official suggestion is to use serverless params](https://www.serverless.com/framework/docs/guides/parameters/) but I am reluctant to introduce a requirement to have a serverless account.