### PR TITLE
Encapsulate harvest more

### DIFF
--- a/src/__snapshots__/index.integration.test.js.snap
+++ b/src/__snapshots__/index.integration.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`hours integration test with all real modules except those in the folder __mocks__ should return meta data for time entries and relevant time entries per day 1`] = `
 Object {
-  "body": "{\\"meta\\":{\\"description\\":\\"*All* unbilled billable hours, and any non-billable hours logged for the current month.\\",\\"totalUnbilledHours\\":10.7,\\"totalUnbilledHoursPerWeek\\":{\\"w45\\":10.7},\\"unbilledInvoice\\":{\\"excludingVAT\\":\\"2354.00 Swedish kronor\\",\\"includingVAT\\":\\"2942.50 Swedish kronor\\"}},\\"timeEntriesPerDay\\":[{\\"date\\":\\"2020-11-06\\",\\"name\\":\\"Programmering\\",\\"billableHours\\":8,\\"comment\\":null},{\\"date\\":\\"2020-11-05\\",\\"name\\":\\"Programmering\\",\\"billableHours\\":2.7,\\"comment\\":null}]}",
+  "body": "{\\"meta\\":{\\"description\\":\\"*All* unbilled billable hours, and any non-billable hours logged for the current month.\\",\\"totalUnbilledHours\\":10.7,\\"totalUnbilledHoursPerWeek\\":{\\"w45\\":10.7},\\"unbilledInvoice\\":{\\"excludingVAT\\":\\"2354.00 Swedish kronor\\",\\"includingVAT\\":\\"2942.50 Swedish kronor\\"}},\\"timeEntriesPerDay\\":[{\\"date\\":\\"2020-11-06\\",\\"name\\":\\"Programmering\\",\\"billableHours\\":8},{\\"date\\":\\"2020-11-05\\",\\"name\\":\\"Programmering\\",\\"billableHours\\":2.7}]}",
   "statusCode": 200,
 }
 `;

--- a/src/npm-package-encapsulation/harvest-queries.js
+++ b/src/npm-package-encapsulation/harvest-queries.js
@@ -1,0 +1,29 @@
+const harvest = require("./authenticated-harvest");
+
+module.exports.getUnbilledTimeEntries = async () => {
+  const timeEntries = await harvest.timeEntries.list({
+    is_billed: "false",
+  });
+  return timeEntries.time_entries.map((timeEntry) =>
+    timeEntry.notes
+      ? {
+          billable: timeEntry.billable,
+          billableRate: timeEntry.billable_rate || 0,
+          comment: timeEntry.notes,
+          date: timeEntry.spent_date,
+          hours: timeEntry.hours,
+          id: timeEntry.id,
+          isBilled: timeEntry.is_billed,
+          name: timeEntry.task.name,
+        }
+      : {
+          billable: timeEntry.billable,
+          billableRate: timeEntry.billable_rate || 0,
+          date: timeEntry.spent_date,
+          hours: timeEntry.hours,
+          id: timeEntry.id,
+          isBilled: timeEntry.is_billed,
+          name: timeEntry.task.name,
+        }
+  );
+};

--- a/src/time-entries.test.js
+++ b/src/time-entries.test.js
@@ -1,12 +1,9 @@
 const timeEntries = require("./time-entries");
-const mockHarvestApi = require("./npm-package-encapsulation/authenticated-harvest");
-const { when } = require("jest-when");
+const {
+  getUnbilledTimeEntries,
+} = require("./npm-package-encapsulation/harvest-queries");
 
-jest.mock("./npm-package-encapsulation/authenticated-harvest", () => ({
-  timeEntries: {
-    list: jest.fn(),
-  },
-}));
+jest.mock("./npm-package-encapsulation/harvest-queries");
 
 jest.mock("./date", () => ({
   startOfMonth: () => Date.parse("2018-11-01"),
@@ -24,18 +21,18 @@ describe(timeEntries.getRelevantUnbilled, () => {
 
     const expected = [
       {
-        id: 1,
-        date: "2018-11-04",
-        name: "Programming",
         billableHours: 4.1,
         cost: 548.17,
+        date: "2018-11-04",
+        id: 1,
+        name: "Programming",
       },
       {
-        id: 4,
-        date: "2018-01-01",
-        name: "Programming",
         billableHours: 7.0,
         cost: 935.9,
+        date: "2018-01-01",
+        id: 4,
+        name: "Programming",
       },
     ];
     expect(result).toEqual(expect.arrayContaining(expected));
@@ -51,11 +48,12 @@ describe(timeEntries.getRelevantUnbilled, () => {
 
     const expected = [
       {
-        id: 2,
-        date: "2018-11-03",
-        name: "Vacation",
         billableHours: 0,
+        comment: "Umeå",
         cost: 0,
+        date: "2018-11-03",
+        id: 2,
+        name: "Vacation",
       },
     ];
     expect(result).toEqual(expect.arrayContaining(expected));
@@ -78,74 +76,56 @@ describe(timeEntries.getRelevantUnbilled, () => {
   });
 
   const setupReturnTimeEntries = (...entries) =>
-    when(mockHarvestApi.timeEntries.list)
-      .calledWith({ is_billed: "false" })
-      .mockReturnValue({
-        time_entries: entries,
-      });
+    getUnbilledTimeEntries.mockReturnValue(entries);
 
   const unbilledBillableDecember = {
-    id: 1,
-    spent_date: "2018-11-04",
-    task: {
-      name: "Programming",
-    },
-    is_billed: false,
     billable: true,
-    billable_rate: 133.7,
+    billableRate: 133.7,
+    date: "2018-11-04",
     hours: 4.12,
-    notes: null,
+    id: 1,
+    isBilled: false,
+    name: "Programming",
   };
 
   const unbilledUnbillableDecember = {
-    id: 2,
-    spent_date: "2018-11-03",
-    task: {
-      name: "Vacation",
-    },
-    is_billed: false,
     billable: false,
-    billable_rate: null,
+    billableRate: null,
+    comment: "Umeå",
+    date: "2018-11-03",
     hours: 8,
-    notes: null,
+    id: 2,
+    isBilled: false,
+    name: "Vacation",
   };
 
   const billedBillableFebruary = {
-    id: 3,
-    spent_date: "2018-02-01",
-    task: {
-      name: "Programming",
-    },
-    is_billed: true,
     billable: true,
-    billable_rate: 133.7,
+    billableRate: 133.7,
+    date: "2018-02-01",
     hours: 7.01,
-    notes: null,
+    id: 3,
+    isBilled: true,
+    name: "Programming",
   };
 
   const unbilledBillableJanuary = {
-    id: 4,
-    spent_date: "2018-01-01",
-    task: {
-      name: "Programming",
-    },
-    is_billed: false,
     billable: true,
-    billable_rate: 133.7,
+    billableRate: 133.7,
+    date: "2018-01-01",
     hours: 7.01,
-    notes: null,
+    id: 4,
+    isBilled: false,
+    name: "Programming",
   };
 
   const unbilledUnbillableJanuary = {
-    id: 5,
-    spent_date: "2018-01-01",
-    task: {
-      name: "Vacation",
-    },
-    is_billed: false,
     billable: false,
-    billable_rate: null,
+    billableRate: null,
+    date: "2018-01-01",
     hours: 6,
-    notes: null,
+    id: 5,
+    isBilled: false,
+    name: "Vacation",
   };
 });


### PR DESCRIPTION
Next step would be to make `authenticated-harvest` obsolete and a part of `harvest-queries`. If we can ensure indirectly that harvest is initiated with the correct options (maybe with `jest-when`) and move the authenticated-harvest integration test over to harvest-queries then it could be inlined/deleted.